### PR TITLE
💫 Enhanced connection line visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -677,8 +677,8 @@
             const linkMaterial = new THREE.LineBasicMaterial({ 
                 color: 0x64f4ff, 
                 transparent: true, 
-                opacity: 0.3,
-                linewidth: 2
+                opacity: 0.5,
+                linewidth: 5
             });
             
             siteData.links.forEach(linkData => {
@@ -1096,8 +1096,8 @@
             const linkMaterial = new THREE.LineBasicMaterial({ 
                 color: 0x64f4ff, 
                 transparent: true, 
-                opacity: 0.3,
-                linewidth: 2
+                opacity: 0.5,
+                linewidth: 5
             });
             
             siteData.links.forEach(linkData => {
@@ -1133,8 +1133,8 @@
             const material = new THREE.LineBasicMaterial({ 
                 color: 0xffff00, 
                 transparent: true, 
-                opacity: 0.7,
-                linewidth: 3
+                opacity: 0.8,
+                linewidth: 6
             });
             
             connectionPreview = new THREE.Line(geometry, material);


### PR DESCRIPTION
- Increased connection line thickness from 2 to 5 pixels
- Increased connection preview line thickness from 3 to 6 pixels
- Improved line opacity for better visibility (0.3→0.5 for regular, 0.7→0.8 for preview)
- Makes node connections much more visible and easier to follow